### PR TITLE
chore(doc): adding more doc in readme and removing svg via gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * linguist-detectable=true
+*.svg linguist-vendored

--- a/README.md
+++ b/README.md
@@ -15,3 +15,22 @@ In order to run the docker compose execute the following statement from the root
 ```docker
 docker compose -f .\build\docker-compose.yml up --build -d
 ```
+
+or you can always pull our latest docker image by running:
+```shell
+docker pull ghcr.io/seg-unibe/artio-relay:latest
+```
+
+# Standalone
+For running standalone see the ```build``` folder where you can find more build scripts. 
+
+# Deployment
+
+The application will then be running on port 8000 by default. 
+In order to forward connections you have to set up a proper proxy on your own hosts or change the docker compose accordingly. 
+
+The use of a HA Proxy or NGINX is highly advised for proper access management. 
+
+
+# Additional Information
+If you have any other questions about the specifics of the implementation and the deployment process, feel free to get in touch


### PR DESCRIPTION
This pull request includes updates to the `.gitattributes` file and significant enhancements to the `README.md` documentation for improved usability and clarity. The changes focus on marking `.svg` files as vendored and providing additional guidance for running, deploying, and managing the application.

### File configuration updates:
* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR2): Marked all `.svg` files as `linguist-vendored` to exclude them from language statistics.

### Documentation enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18-R36): Expanded the documentation to include instructions for pulling the latest Docker image, standalone execution, deployment recommendations (e.g., using HA Proxy or NGINX), and additional contact information for support.